### PR TITLE
Update licensing packages and switch to CountryInfo

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="EasyDoubles" Version="1.1.19" />
-    <PackageVersion Include="Fossa.Licensing" Version="1.2.3" />
+    <PackageVersion Include="Fossa.Licensing" Version="1.3.0" />
     <PackageVersion Include="FSharp.Core" Version="10.0.103" />
     <PackageVersion Include="MediatR" Version="14.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="10.0.8" />
@@ -20,8 +20,8 @@
     <PackageVersion Include="ReportGenerator" Version="5.5.7" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="SharpCompress" Version="0.48.1" />
-    <PackageVersion Include="TIKSN-Framework" Version="5.6.6" />
-    <PackageVersion Include="VerdantApp.Licensing" Version="1.1.2" />
+    <PackageVersion Include="TIKSN-Framework" Version="5.7.0" />
+    <PackageVersion Include="VerdantApp.Licensing" Version="1.1.3" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/src/CovenantCouncil.Infrastructure/Licenses/LicenseService.cs
+++ b/src/CovenantCouncil.Infrastructure/Licenses/LicenseService.cs
@@ -12,6 +12,7 @@ using LanguageExt;
 using LanguageExt.Common;
 using Microsoft.EntityFrameworkCore;
 using TIKSN.Deployment;
+using TIKSN.Globalization;
 using TIKSN.Licensing;
 using FossaCompanyEntitlements = Fossa.Licensing.CompanyEntitlements;
 using FossaSystemEntitlements = Fossa.Licensing.SystemEntitlements;
@@ -23,6 +24,7 @@ public sealed class LicenseService(
   IDbContextFactory<CovenantCouncilDbContext> dbContextFactory,
   IPortableProtectionService protectionService,
   ILicenseCatalog licenseCatalog,
+  ICountryFactory countryFactory,
   IServiceProvider serviceProvider) : ILicenseService
 {
   public async Task<IReadOnlyList<LicenseSummary>> ListAsync(string? descriptorDiscriminator, CancellationToken cancellationToken = default)
@@ -205,7 +207,7 @@ public sealed class LicenseService(
       ParseInt32(values, LicenseEntitlementFields.MaximumDepartmentCount));
   }
 
-  private static FossaSystemEntitlements CreateFossaSystemEntitlements(IReadOnlyDictionary<string, string> values)
+  private FossaSystemEntitlements CreateFossaSystemEntitlements(IReadOnlyDictionary<string, string> values)
   {
     return new FossaSystemEntitlements(
       ParseUlid(values, LicenseEntitlementFields.SystemId),
@@ -214,7 +216,7 @@ public sealed class LicenseService(
       LanguageExt.Prelude.Seq(ParseCountries(values)));
   }
 
-  private static VerdantSystemEntitlements CreateVerdantSystemEntitlements(IReadOnlyDictionary<string, string> values)
+  private VerdantSystemEntitlements CreateVerdantSystemEntitlements(IReadOnlyDictionary<string, string> values)
   {
     return new VerdantSystemEntitlements(
       ParseUlid(values, LicenseEntitlementFields.SystemId),
@@ -222,7 +224,7 @@ public sealed class LicenseService(
       LanguageExt.Prelude.Seq(ParseCountries(values)));
   }
 
-  private static RegionInfo[] ParseCountries(IReadOnlyDictionary<string, string> values)
+  private CountryInfo[] ParseCountries(IReadOnlyDictionary<string, string> values)
   {
     var countryCodes = Require(values, LicenseEntitlementFields.CountryCodes)
       .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
@@ -234,7 +236,7 @@ public sealed class LicenseService(
       throw new InvalidOperationException("At least one country must be selected.");
     }
 
-    return [.. countryCodes.Select(code => new RegionInfo(code))];
+    return [.. countryCodes.Select(countryFactory.Create)];
   }
 
   private static int ParseInt32(IReadOnlyDictionary<string, string> values, string key)


### PR DESCRIPTION
## Summary
- Bump `Fossa.Licensing`, `TIKSN-Framework`, and `VerdantApp.Licensing` to the updated package versions.
- Replace the old `RegionInfo`-based country handling in `LicenseService` with `TIKSN.Globalization.CountryInfo`.
- Inject `ICountryFactory` so the updated Fossa and Verdant entitlement constructors receive the expected type.

## Testing
- Built the affected net10 projects successfully: infrastructure, functional tests, and integration tests.
- Ran the test suite for the net10 projects; functional and integration tests passed.
- Full solution build still hits an unrelated Android file लॉक/lock issue in the app target.